### PR TITLE
Display "Version" in Library title 

### DIFF
--- a/Demo/TestLib.ahk
+++ b/Demo/TestLib.ahk
@@ -1,11 +1,12 @@
 /*!
-	Library: Test library, version 1.0
+	Library: Test library
 		This library does something
 		
 		or maybe not!  
 		In-paragraph line breaks work
 	Author: fincs
 	License: WTFPL
+	Version: 1.0
 */
 
 /*!

--- a/Lib/GenerateDocs.ahk
+++ b/Lib/GenerateDocs.ahk
@@ -14,8 +14,11 @@ GenerateDocs(file, docs)
 	
 	libname := docs.name
 	libdesc := docs.description
+	libextra := 
+	if docs.version
+		libextra .= " - Version " _HTML(docs.version)
 	if docs.author
-		libextra := " - by " _HTML(docs.author)
+		libextra .= " - by " _HTML(docs.author)
 	if docs.license
 		libextra .= " - released under the " _HTML(docs.license)
 	


### PR DESCRIPTION
Generating the main library documentation page the contents of author and the license fileds are included in pagetitle.
Include a Version field as well.
